### PR TITLE
CUMULUS-686: store task name/version/arn in meta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+- Use updated message adapter to store task metadata.
+
 ## [v1.0.3] - 2018-07-26
 
 - Fixed location for pulling execution name.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-- Use updated message adapter to store task metadata.
+## [v1.0.4] - 2018-08-16
+### Added
+
+- Store task context metadata in `meta.workflow_tasks`, if it exists.
 
 ## [v1.0.3] - 2018-07-26
 

--- a/index.js
+++ b/index.js
@@ -56,17 +56,14 @@ function callCumulusMessageAdapter(command, input) {
  * If a Cumulus Remote Message is passed, fetch it and return a full Cumulus Message with updated task metadata.
  *
  * @param {Object} cumulusMessage - either a full Cumulus Message or a Cumulus Remote Message
+ * @param {Object} context - an AWS Lambda context
  * @param {string} schemaLocations - contains location of schema files, can be null
  * @returns {Promise.<Object>} - a full Cumulus Message
  */
 function loadAndUpdateRemoteEvent(cumulusMessage, context, schemaLocations) {
   return callCumulusMessageAdapter('loadAndUpdateRemoteEvent', {
     event: cumulusMessage,
-    context: {
-      function_name: context.functionName,
-      function_version: context.functionVersion,
-      invoked_function_arn: context.invokedFunctionArn
-    },
+    context,
     schemas: schemaLocations
   });
 }

--- a/index.js
+++ b/index.js
@@ -152,6 +152,10 @@ function runCumulusTask(taskFunction, cumulusMessage, context, callback, schemas
     );
   }
   else {
+    if (cumulusMessage.meta && cumulusMessage.meta.workflow_tasks) {
+      cumulusMessage.meta.workflow_tasks[context.functionName] = { version: context.functionVersion, arn: context.invokedFunctionArn };
+    }
+
     const promisedRemoteEvent = loadRemoteEvent(cumulusMessage, schemas);
     const promisedNestedEvent = promisedRemoteEvent
       .then((event) => loadNestedEvent(event, context, schemas));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cumulus/cumulus-message-adapter-js",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Cumulus message adapter",
   "main": "index.js",
   "scripts": {

--- a/test/test-index-with-dir-env.js
+++ b/test/test-index-with-dir-env.js
@@ -15,6 +15,7 @@ test.cb('CUMULUS_MESSAGE_ADAPTER_DIR sets the location of the message adapter', 
   const expectedOutput = {
     event: {
       event: inputEvent,
+      context: {},
       schemas: null
     },
     handler_response: businessLogicOutput,

--- a/test/test-index.js
+++ b/test/test-index.js
@@ -10,6 +10,7 @@ test.cb('The correct cumulus message is returned', (t) => {
   const expectedOutput = {
     event: {
       event: inputEvent,
+      context: {},
       schemas: null
     },
     handler_response: businessLogicOutput,
@@ -35,6 +36,7 @@ test.cb('Correct cumulus message is returned when task returns a promise that re
   const expectedOutput = {
     event: {
       event: inputEvent,
+      context: {},
       schemas: null
     },
     handler_response: businessLogicOutput,
@@ -56,7 +58,7 @@ test.cb('The businessLogic receives the correct arguments', (t) => {
   const context = { b: 2 };
 
   const expectedNestedEvent = {
-    event: { event: { a: 1 }, schemas: null },
+    event: { event: { a: 1 }, context: {}, schemas: null },
     schemas: null,
     context: { b: 2 }
   };

--- a/test/test-index.js
+++ b/test/test-index.js
@@ -58,9 +58,9 @@ test.cb('The businessLogic receives the correct arguments', (t) => {
   const context = { b: 2 };
 
   const expectedNestedEvent = {
-    event: { event: { a: 1 }, context: {}, schemas: null },
+    event: { event: { a: 1 }, context, schemas: null },
     schemas: null,
-    context: { b: 2 }
+    context
   };
 
   function businessLogic(actualNestedEvent, actualContext) {


### PR DESCRIPTION
Gets function name/version/arn from context and stores it in cumulus_meta.
Dependent on changes to cumulus message template constructor to add a `workflow_tasks` object to `meta`, in the `CUMULUS-686` branch of `nasa/cumulus`.