### PR TITLE
CUMULUS-906: Remove environment variable `REINGEST_GRANULE`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [v1.0.7] - 2018-11-08
+
+### Removed
+- Remove environment variable `REINGEST_GRANULE` which was used to indicate if the granule is manually reingested [CUMULUS-906]
+
 ## [v1.0.6] - 2018-11-07
 
 ### Added
@@ -43,7 +48,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 Initial release
 
 [Unreleased]:
-https://github.com/nasa/cumulus-cumulus-message-adapter-js/compare/v1.0.6...HEAD
+https://github.com/nasa/cumulus-cumulus-message-adapter-js/compare/v1.0.7...HEAD
+[v1.0.7]:
+https://github.com/nasa/cumulus-cumulus-message-adapter-js/compare/v1.0.6...v1.0.7
 [v1.0.6]:
 https://github.com/nasa/cumulus-cumulus-message-adapter-js/compare/v1.0.5...v1.0.6
 [v1.0.5]:

--- a/index.js
+++ b/index.js
@@ -159,11 +159,7 @@ function runCumulusTask(taskFunction, cumulusMessage, context, callback, schemas
   else {
     const promisedRemoteEvent = loadAndUpdateRemoteEvent(cumulusMessage, context, schemas);
     const promisedNestedEvent = promisedRemoteEvent
-      .then((event) => {
-        // indicate if the granule is manually reingested
-        process.env.REINGEST_GRANULE = (event.meta.reingestGranule === true);
-        return loadNestedEvent(event, context, schemas);
-      });
+      .then((event) => loadNestedEvent(event, context, schemas));
 
     const promisedTaskOutput = promisedNestedEvent
       .then((nestedEvent) => taskFunction(nestedEvent, context));

--- a/test/test-index.js
+++ b/test/test-index.js
@@ -154,15 +154,18 @@ test.cb('A Promise WorkflowError is returned properly', (t) => {
   return cumulusMessageAdapter.runCumulusTask(businessLogic, testContext.inputEvent, {}, callback);
 });
 
-test.cb('The task receives the correct environment variables', (t) => {
+test.cb('The task receives the cumulus_config property', (t) => {
   const context = { b: 2 };
 
   const inputEvent = clonedeep(testContext.inputEvent);
-  inputEvent.meta.reingestGranule = true;
+  inputEvent.cumulus_meta.cumulus_context = { anykey: 'anyvalue' };
 
   function businessLogic(actualNestedEvent, actualContext) {
     t.deepEqual(actualContext, context);
-    t.is(process.env.REINGEST_GRANULE, 'true');
+    t.deepEqual(
+      actualNestedEvent.cumulus_config.cumulus_context,
+      inputEvent.cumulus_meta.cumulus_context
+    );
     return 42;
   }
 


### PR DESCRIPTION
Remove environment variable `REINGEST_GRANULE` which was used to indicate if the granule is manually reingested.
We are using different approach to pass the information to the tasks.  See
https://github.com/nasa/cumulus-message-adapter/pull/54