### PR TITLE
Cumulus 2203 update to core3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,21 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic
 Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [v2.0.0] 2020-10-19
+
+### BREAKING CHANGES
+
+- **CUMULUS-2203**
+  - Updated CumulusMessageWithPayload exported to
+    CumulusMessageWithAssignedPayload.  This change explicitly updates this type
+    to allow for a `null` payload value, as well as explicitly allows for a
+    `replace` key for compatibility with `@cumulus/types` > 3.0.0
+
 ## [v1.3.2] 2020-10-13
 
 ### Fixed
+
+- **CUMULUS_2203**
 
 - Fixed issue causing spawned CMA process to left running/in the node event
   queue, resulting in AWS being unwilling/unable to clean up the instance. This resulted in lambdas with a memory leak/resource issues to not be

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cumulus/cumulus-message-adapter-js",
-  "version": "1.3.2",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -212,9 +212,9 @@
       }
     },
     "@cumulus/types": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@cumulus/types/-/types-2.0.1.tgz",
-      "integrity": "sha512-F5v6aBYMf1CdHevBP8l2+MxI0F1fNg/4L6MGgoMVvhuGIcW7iqI2QYNTJWl63Eglk8OhYXv5Oh6Yh0OwjEu2Ew=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@cumulus/types/-/types-3.0.0.tgz",
+      "integrity": "sha512-qHqKIyLyWhDYBAPR01l1yCBrpWp07hE2RVnEThpZIQb3638I94LoD6DkQzluiRI59K7k4uP3GNqGfAtimL6PqQ=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cumulus/cumulus-message-adapter-js",
-  "version": "1.3.2",
+  "version": "2.0.0",
   "description": "Cumulus message adapter",
   "main": "dist/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   },
   "dependencies": {
     "@types/aws-lambda": "^8.10.58",
-    "@cumulus/types": "2.0.1",
+    "@cumulus/types": "3.0.0",
     "execa": "^4.0.0",
     "lookpath": "1.0.3"
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,3 +3,5 @@ export {
   invokeCumulusMessageAdapter,
   runCumulusTask
 } from './cma';
+
+export * from './types';

--- a/src/message.ts
+++ b/src/message.ts
@@ -1,4 +1,4 @@
-import { CumulusMessageWithPayload } from './types';
+import { CumulusMessageWithAssignedPayload } from './types';
 
 const GRANULE_LOG_LIMIT = 500;
 /**
@@ -12,7 +12,7 @@ const GRANULE_LOG_LIMIT = 500;
  * @returns {Array<string>} - An array of granule ids
  */
 export const getMessageGranules = (
-  message: CumulusMessageWithPayload,
+  message: CumulusMessageWithAssignedPayload,
   granuleLimit: number = GRANULE_LOG_LIMIT
 ): string[] => {
   const granules = message?.payload?.granules || message?.meta?.input_granules;
@@ -30,7 +30,7 @@ export const getMessageGranules = (
  * @returns {string | undefined} - The cumulus stack name.
  */
 export const getStackName = (
-  message: CumulusMessageWithPayload
+  message: CumulusMessageWithAssignedPayload
 ): string | undefined => message?.meta?.stack;
 
 /**
@@ -40,7 +40,7 @@ export const getStackName = (
  * @returns {string | undefined} - the parent execution.
  */
 export const getParentArn = (
-  message: CumulusMessageWithPayload
+  message: CumulusMessageWithAssignedPayload
 ): string | undefined => message?.cumulus_meta?.parentExecutionArn;
 
 /**
@@ -50,7 +50,7 @@ export const getParentArn = (
 * @returns {string | undefined} current execution name.
 */
 export const getExecutions = (
-  message: CumulusMessageWithPayload
+  message: CumulusMessageWithAssignedPayload
 ): string | undefined => message?.cumulus_meta?.execution_name;
 
 /**
@@ -60,5 +60,5 @@ export const getExecutions = (
  * @returns {string} asyncOperationId or null
  */
 export const getAsyncOperationId = (
-  message: CumulusMessageWithPayload
+  message: CumulusMessageWithAssignedPayload
 ): string | undefined => message?.cumulus_meta?.asyncOperationId;

--- a/src/typeGuards.ts
+++ b/src/typeGuards.ts
@@ -1,20 +1,20 @@
 import { CumulusMessage, CumulusRemoteMessage } from '@cumulus/types/message';
 import {
   LoadNestedEventInput,
-  CumulusMessageWithPayload,
+  CumulusMessageWithAssignedPayload,
   CMAMessage
 } from './types';
 
 // eslint-disable-next-line require-jsdoc
-export function isCumulusMessageWithPayload(
+export function isCumulusMessageWithAssignedPayload(
   message:
   CumulusMessage |
   CumulusRemoteMessage |
-  CumulusMessageWithPayload |
+  CumulusMessageWithAssignedPayload |
   LoadNestedEventInput
-): message is CumulusMessageWithPayload {
+): message is CumulusMessageWithAssignedPayload {
   return (
-    (message as CumulusMessageWithPayload)?.payload !== undefined
+    (message as CumulusMessageWithAssignedPayload)?.payload !== undefined
     && (message as LoadNestedEventInput)?.input === undefined
     && (message as LoadNestedEventInput)?.config === undefined
   );
@@ -22,7 +22,7 @@ export function isCumulusMessageWithPayload(
 
 // eslint-disable-next-line require-jsdoc
 export function isLoadNestedEventInput(
-  message: CumulusMessageWithPayload | LoadNestedEventInput | CumulusRemoteMessage
+  message: CumulusMessageWithAssignedPayload | LoadNestedEventInput | CumulusRemoteMessage
 ): message is LoadNestedEventInput {
   return (
     (message as LoadNestedEventInput).input !== undefined

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,14 +13,18 @@ export interface LoadNestedEventInput {
   config: unknown,
   messageConfig?: unknown
 }
-export interface CumulusMessageWithPayload extends CumulusMessage {
+export interface CumulusMessageWithAssignedPayload extends CumulusMessage {
   payload: {
     granules?: { granuleId: string }[]
-  }
+    [key: string]: unknown
+  } | null,
   meta: {
+    workflow_name: string
+    [key: string]: unknown
     stack?: string,
     input_granules?: { granuleId: string }[]
   }
+  replace?: ReplaceConfig
 }
 export interface CMAMessage {
   cma: {


### PR DESCRIPTION
This PR updates cma-js to work with Core v3.0.0+ message typings and addresses feedback from https://github.com/nasa/cumulus/pull/1931

