### PR TITLE
Update cma-js to handle lambda timeouts more gracefully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic
 Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [v2.0.1] 2021-11-10
+## [v2.0.1] 2021-11-17
 
 - **CUMULUS-2745**
   - Updates logging to always log CMA stderr on function timeout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic
 Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [v2.0.1] 2021-11-10
+
+- **CUMULUS-2745**
+  - Adds a timer function that will kill the CMA process/lambda prior to
+    an AWS interrupt to avoid losing the diagnostic logs
+  - Updates the lambda to always log stderr on lambda timeout
+
 ## [v2.0.0] 2020-10-19
 
 ### BREAKING CHANGES

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ## [v2.0.1] 2021-11-10
 
 - **CUMULUS-2745**
-  - Adds a timer function that will kill the CMA process/lambda prior to
-    an AWS interrupt to avoid losing the diagnostic logs
-  - Updates the lambda to always log stderr on lambda timeout
+  - Updates logging to always log CMA stderr on function timeout
 
 ## [v2.0.0] 2020-10-19
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cumulus/cumulus-message-adapter-js",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Cumulus message adapter",
   "main": "dist/index.js",
   "files": [

--- a/src/cma.ts
+++ b/src/cma.ts
@@ -217,7 +217,7 @@ export async function runCumulusTask(
     console.log('Starting task function');
     const taskOutput = await TaskFunction(loadNestedEventOutput, context);
     console.log('Starting task function finished');
-    
+
     cmaStdin.write('createNextEvent\n');
     cmaStdin.write(JSON.stringify({
       event: loadAndUpdateRemoteEventOutput,

--- a/test/test-index-with-dir-env.js
+++ b/test/test-index-with-dir-env.js
@@ -6,6 +6,8 @@ const path = require('path');
 const cumulusMessageAdapter = require('../dist/index');
 const { downloadCMA } = require('./adapter');
 
+const handlerContext = { getRemainingTimeInMillis: () => Promise.resolve(10000) };
+
 // store test context data
 const testContext = {};
 
@@ -39,7 +41,7 @@ test('CUMULUS_MESSAGE_ADAPTER_DIR sets the location of the message adapter', asy
   const result = await cumulusMessageAdapter.runCumulusTask(
     businessLogic,
     testContext.inputEvent,
-    {}
+    handlerContext
   );
   t.deepEqual(result, expectedOutput);
 });
@@ -53,5 +55,11 @@ test('callback returns error if CUMULUS_MESSAGE_ADAPTER_DIR is incorrect', async
 
   const inputEvent = { a: 1 };
 
-  await t.throwsAsync(cumulusMessageAdapter.runCumulusTask(businessLogic, inputEvent, {}));
+  await t.throwsAsync(
+    cumulusMessageAdapter.runCumulusTask(
+      businessLogic,
+      inputEvent,
+      handlerContext
+    )
+  );
 });

--- a/test/test-index.js
+++ b/test/test-index.js
@@ -11,6 +11,7 @@ const cumulusMessageAdapter = proxyquire('../dist/index', {
 });
 const { downloadCMA } = require('./adapter');
 
+const handlerContext = { getRemainingTimeInMillis: () => Promise.resolve(10000) };
 // store test context data
 const testContext = {};
 
@@ -60,7 +61,7 @@ test.serial('Execution is set when parameterized configuration is set', async(t)
   const businessLogic = () => Promise.resolve(process.env.EXECUTIONS);
   const expectedOutput = 'execution_value';
   const actual = await cumulusMessageAdapter.runCumulusTask(
-    businessLogic, testContext.paramInputEvent, {}
+    businessLogic, testContext.paramInputEvent, handlerContext
   );
   t.is(expectedOutput, actual.payload);
 });
@@ -111,7 +112,7 @@ test.serial('A WorkflowError is returned properly', async(t) => {
   const actual = await cumulusMessageAdapter.runCumulusTask(
     businessLogic,
     testContext.inputEvent,
-    {}
+    handlerContext
   );
   t.deepEqual(expectedOutput, actual);
 });
@@ -123,7 +124,7 @@ test.serial('A non-WorkflowError is raised', async(t) => {
   await t.throwsAsync(cumulusMessageAdapter.runCumulusTask(
     businessLogic,
     testContext.inputEvent,
-    {}
+    handlerContext
   ),
   { message: 'oh snap', name: 'Error' });
 });
@@ -134,7 +135,7 @@ test.serial('A promise returns an error', async(t) => {
   }
 
   await t.throwsAsync(cumulusMessageAdapter.runCumulusTask(businessLogic,
-    testContext.inputEvent, {}),
+    testContext.inputEvent, handlerContext),
   { name: 'Error', message: 'oh no' });
 });
 
@@ -149,12 +150,12 @@ test.serial('A Promise WorkflowError is returned properly', async(t) => {
     return Promise.reject(error);
   }
   const actual = await cumulusMessageAdapter.runCumulusTask(businessLogic,
-    testContext.inputEvent, {});
+    testContext.inputEvent, handlerContext);
   t.deepEqual(expectedOutput, actual);
 });
 
 test.serial('The task receives the cumulus_config property', async(t) => {
-  const context = { b: 2 };
+  const context = { ...handlerContext, b: 2 };
 
   const inputEvent = clonedeep(testContext.inputEvent);
   inputEvent.cumulus_meta.cumulus_context = { anykey: 'anyvalue' };

--- a/test/test-index.js
+++ b/test/test-index.js
@@ -77,7 +77,7 @@ test.serial('Correct cumulus message is returned when task returns a promise tha
     const actual = await cumulusMessageAdapter.runCumulusTask(
       businessLogic,
       testContext.inputEvent,
-      {}
+      handlerContext
     );
     t.deepEqual(expectedOutput, actual);
   });

--- a/test/test-index.js
+++ b/test/test-index.js
@@ -83,7 +83,7 @@ test.serial('Correct cumulus message is returned when task returns a promise tha
   });
 
 test.serial('The businessLogic receives the correct arguments', async(t) => {
-  const context = { b: 2 };
+  const context = { ...handlerContext, b: 2 };
 
   const expectedNestedEvent = {
     input: testContext.inputEvent.payload,

--- a/test/test-message.js
+++ b/test/test-message.js
@@ -13,7 +13,7 @@ const {
 
 const testContext = {};
 
-test.before(async () => {
+test.before(async() => {
   const inputJson = path.join(__dirname, 'fixtures/messages/basic.input.json');
   testContext.inputEvent = JSON.parse(fs.readFileSync(inputJson));
   const granuleInputJson = path.join(__dirname, 'fixtures/messages/execution.granule.input.json');


### PR DESCRIPTION
- Adds a timer function that will kill the CMA process/lambda prior to
an AWS interrupt to avoid losing the diagnostic logs
- Updates the lambda to always log stderr on lambda timeout