### PR TITLE
Fix bug in situation where context.getRemainingTimeInMillis is undefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,16 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic
 Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [v2.0.3] 2021-11-20
+
+### Fixed
+
+- **CUMULUS-2745**
+  - Bug fix/patch release to fix issue where Lambda execution contexts like ECS tasks that did not have an AWS Lambda `context` object with a `getRemainingTimeInMillis` method resulted in task failure
+
 ## [v2.0.2] 2021-11-17
+
+### Updated
 
 - **CUMULUS-2745**
   - Updates logging to always log CMA stderr on function timeout

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cumulus/cumulus-message-adapter-js",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Cumulus message adapter",
   "main": "dist/index.js",
   "files": [

--- a/src/cma.ts
+++ b/src/cma.ts
@@ -184,10 +184,17 @@ export async function runCumulusTask(
     input: cmaProcess.stdout
   });
 
-  const lambdaTimer = setTimeout(() => {
-    console.log('Lambda timing out, writing CMA stderr to cloudwatch logs');
-    console.log(`CMA (on start task timeout) StdErr: \n ${errorObj.stderrBuffer}`);
-  }, context.getRemainingTimeInMillis() - 5 * 100);
+  let lambdaTimer = setTimeout(() => {
+    console.log(
+      'Info: No CMA buffer dump set, lambda is not running as a lambda'
+    );
+  }, 0);
+  if (typeof context.getRemainingTimeInMillis === 'function') {
+    lambdaTimer = setTimeout(() => {
+      console.log('Lambda timing out, writing CMA stderr to cloudwatch logs');
+      console.log(`CMA (on start task timeout) StdErr: \n ${errorObj.stderrBuffer}`);
+    }, context.getRemainingTimeInMillis() - 5 * 100);
+  }
   try {
     cmaStdin.write('loadAndUpdateRemoteEvent\n');
     cmaStdin.write(JSON.stringify({

--- a/test/test-index.js
+++ b/test/test-index.js
@@ -99,6 +99,29 @@ test.serial('The businessLogic receives the correct arguments', async(t) => {
     .runCumulusTask(businessLogic, testContext.inputEvent, context);
 });
 
+test.serial(
+  'businessLogic recieves expected args when lambda context is missing getRemainingTimeInMillis',
+  async (t) => {
+    const context = { b: 2 };
+
+    const expectedNestedEvent = {
+      input: testContext.inputEvent.payload,
+      config: testContext.inputEvent.task_config,
+    };
+
+    function businessLogic(actualNestedEvent, actualContext) {
+      t.deepEqual(actualNestedEvent, expectedNestedEvent);
+      t.deepEqual(actualContext, context);
+      return 42;
+    }
+    await cumulusMessageAdapter.runCumulusTask(
+      businessLogic,
+      testContext.inputEvent,
+      context
+    );
+  }
+);
+
 test.serial('A WorkflowError is returned properly', async(t) => {
   const expectedOutput = clonedeep(testContext.outputEvent);
   expectedOutput.payload = null;


### PR DESCRIPTION
This PR addresses a bug when used in conjunction with cumulus-ecs-task where context.getRemainingTimeInMillis isn't defined as it's not being run in an AWS Lambda context. 