### PR TITLE
Ensure that Python is spawned in UTF-8 mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic
 Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- **CUMULUS-3947**
+  - Modified cumulus-message-adapter spawn to put Python into UTF-8 mode
 
 ## [v2.2.0] 2024-04-25
 

--- a/src/cma.ts
+++ b/src/cma.ts
@@ -43,14 +43,14 @@ class CumulusMessageAdapterExecutionError extends Error {
  * @param {string} command - the action to be performed by the message-adapter
  * @returns {Promise.<Array>} - Returns arguments used to spawn the CMA
  */
-export async function generateCMASpawnArguments(command: string): Promise<[string, string[]]> {
+export async function generateCMASpawnArguments(command: string): Promise<[string, string[], Object]> {
   const adapterDir = process.env.CUMULUS_MESSAGE_ADAPTER_DIR ?? './cumulus-message-adapter';
   const systemPython = await lookpath('python');
   if (systemPython && process.env.USE_CMA_BINARY !== 'true') {
-    return [systemPython, [`${adapterDir}`, command]];
+    return [systemPython, [`${adapterDir}`, command], { env: { ...process.env, PYTHONUTF8: 1 } }];
   }
   // If there is no system python, attempt use of pre-packaged CMA binary
-  return [`${adapterDir}/cma_bin/cma`, [command]];
+  return [`${adapterDir}/cma_bin/cma`, [command], { env: { ...process.env, PYTHONUTF8: 1 } }];
 }
 
 /**


### PR DESCRIPTION
Previously, Python was being spawned with no clearly established encoding. This resulted in corruption in Cumulus messages that contained non-ASCII Unicode characters.

In future versions of Python (3.15+), UTF-8 mode will be the default for cases such as this. Until then, setting the PYTHONUTF8 environment variable prior to start of the runtime will accomplish the same thing. See PEP 686.