### PR TITLE
[CUMULUS-3947] Explicitly define default encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic
 Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- **CUMULUS-3947**
+  - Modified cumulus-message-adapter spawn to put Python into UTF-8 mode
 
 ## [v2.2.0] 2024-04-25
 

--- a/src/cma.ts
+++ b/src/cma.ts
@@ -43,7 +43,9 @@ class CumulusMessageAdapterExecutionError extends Error {
  * @param {string} command - the action to be performed by the message-adapter
  * @returns {Promise.<Array>} - Returns arguments used to spawn the CMA
  */
-export async function generateCMASpawnArguments(command: string): Promise<[string, string[], Object]> {
+export async function generateCMASpawnArguments(
+  command: string
+): Promise<[string, string[], Object]> {
   const adapterDir = process.env.CUMULUS_MESSAGE_ADAPTER_DIR ?? './cumulus-message-adapter';
   const systemPython = await lookpath('python');
   if (systemPython && process.env.USE_CMA_BINARY !== 'true') {

--- a/src/cma.ts
+++ b/src/cma.ts
@@ -43,14 +43,14 @@ class CumulusMessageAdapterExecutionError extends Error {
  * @param {string} command - the action to be performed by the message-adapter
  * @returns {Promise.<Array>} - Returns arguments used to spawn the CMA
  */
-export async function generateCMASpawnArguments(command: string): Promise<[string, string[]]> {
+export async function generateCMASpawnArguments(command: string): Promise<[string, string[], Object]> {
   const adapterDir = process.env.CUMULUS_MESSAGE_ADAPTER_DIR ?? './cumulus-message-adapter';
   const systemPython = await lookpath('python');
   if (systemPython && process.env.USE_CMA_BINARY !== 'true') {
-    return [systemPython, [`${adapterDir}`, command]];
+    return [systemPython, [`${adapterDir}`, command], { env: { ...process.env, PYTHONUTF8: 1 } }];
   }
   // If there is no system python, attempt use of pre-packaged CMA binary
-  return [`${adapterDir}/cma_bin/cma`, [command]];
+  return [`${adapterDir}/cma_bin/cma`, [command], { env: { ...process.env, PYTHONUTF8: 1 } }];
 }
 
 /**


### PR DESCRIPTION
Pulling in https://github.com/nasa/cumulus-message-adapter-js/pull/70

This is a user contribution that explicitly sets the default encoding to UTF8. See this article: https://peps.python.org/pep-0686/

Previously the default would be platform-dependent. Most other frameworks/tools use UTF-8 as the standard and Python will as well once we upgrade. This brings the change forward sooner.